### PR TITLE
Fix Xcode 26 concurrency issue

### DIFF
--- a/Sources/Dub/Dub.swift
+++ b/Sources/Dub/Dub.swift
@@ -13,6 +13,7 @@ import TVUIKit
 public actor Dub {
     // MARK: - Dub instance
     nonisolated(unsafe) private(set) static var _shared: Dub!
+    private static let lock = NSLock()
 
     public static var shared: Dub {
         guard let dub = _shared else {
@@ -52,7 +53,9 @@ public actor Dub {
         domain: String,
         baseUrl: URL? = nil
     ) {
-        _shared = Dub(publishableKey: publishableKey, domain: domain, baseUrl: baseUrl)
+        lock.withLock {
+            _shared = Dub(publishableKey: publishableKey, domain: domain, baseUrl: baseUrl)
+        }
     }
 
     // MARK: - Tracking Methods

--- a/Sources/Dub/Dub.swift
+++ b/Sources/Dub/Dub.swift
@@ -12,7 +12,7 @@ import TVUIKit
 
 public actor Dub {
     // MARK: - Dub instance
-    private static var _shared: Dub!
+    nonisolated(unsafe) private(set) static var _shared: Dub!
 
     public static var shared: Dub {
         guard let dub = _shared else {


### PR DESCRIPTION
Updating to Xcode 26 introduced a concurrency issue on the shared instance here. `nonisolated(unsafe)` + a lock on the setting of it fixes it because it is only safely set with the lock